### PR TITLE
No scan_privkey in Receiver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ receiving = []
 secp256k1 = {version = "0.24", features = ["bitcoin-hashes-std"] }
 hex = "0.4"
 bech32 = "0.9"
+bimap = "0.6"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/src/receiving.rs
+++ b/src/receiving.rs
@@ -9,6 +9,7 @@ use crate::{
     Error,
 };
 use bech32::ToBase32;
+use bimap::BiMap;
 use secp256k1::{Parity, PublicKey, Scalar, Secp256k1, SecretKey, XOnlyPublicKey};
 
 use crate::Result;
@@ -90,8 +91,8 @@ impl From<Label> for Scalar {
 pub struct Receiver {
     version: u8,
     scan_privkey: SecretKey,
-    spend_privkey: SecretKey,
-    labels: HashMap<PublicKey, Label>,
+    spend_pubkey: PublicKey,
+    labels: BiMap<Label, PublicKey>,
     is_testnet: bool,
 }
 
@@ -99,10 +100,10 @@ impl Receiver {
     pub fn new(
         version: u32,
         scan_privkey: SecretKey,
-        spend_privkey: SecretKey,
+        spend_pubkey: PublicKey,
         is_testnet: bool,
     ) -> Result<Self> {
-        let labels: HashMap<PublicKey, Label> = HashMap::new();
+        let labels: BiMap<Label, PublicKey> = BiMap::new();
 
         // Check version, we just refuse anything other than 0 for now
         if version != 0 {
@@ -114,7 +115,7 @@ impl Receiver {
         Ok(Receiver {
             version: version as u8,
             scan_privkey,
-            spend_privkey,
+            spend_pubkey,
             labels,
             is_testnet,
         })
@@ -125,14 +126,17 @@ impl Receiver {
     pub fn add_label(&mut self, label: Label) -> Result<bool> {
         let secp = Secp256k1::new();
 
-        let secret = SecretKey::from_slice(&label.as_inner().to_be_bytes())?;
-        let old_value = self.labels.insert(secret.public_key(&secp), label);
-        Ok(old_value.is_none())
+        let m = SecretKey::from_slice(&label.as_inner().to_be_bytes())?;
+        let mG = m.public_key(&secp);
+
+        let old = self.labels.insert(label, mG);
+
+        Ok(!old.did_overwrite())
     }
 
     /// List all currently known labels used by this recipient.
     pub fn list_labels(&self) -> HashSet<Label> {
-        self.labels.values().cloned().collect()
+        self.labels.left_values().cloned().collect()
     }
 
     /// Get the bech32m-encoded silent payment address for a specific label.
@@ -152,15 +156,13 @@ impl Receiver {
     /// * If the label is not known for this recipient.
     /// * If key addition results in an invalid key.
     pub fn get_receiving_address_for_label(&self, label: &Label) -> Result<String> {
-        let secp = Secp256k1::new();
-
-        let b_m = if self.labels.values().any(|l| l.eq(label)) {
-            self.spend_privkey.add_tweak(label.as_inner())?
-        } else {
-            return Err(Error::InvalidLabel("Label not known".to_owned()));
-        };
-
-        Ok(self.encode_silent_payment_address(b_m.public_key(&secp)))
+        match self.labels.get_by_left(label) {
+            Some(mG) => {
+                let B_m = mG.combine(&self.spend_pubkey)?;
+                Ok(self.encode_silent_payment_address(B_m))
+            }
+            None => Err(Error::InvalidLabel("Label not known".to_owned())),
+        }
     }
 
     /// Get the bech32m-encoded silent payment address.
@@ -169,9 +171,7 @@ impl Receiver {
     ///
     /// If successful, the function returns a `String`, which is the bech32m encoded silent payment address.
     pub fn get_receiving_address(&self) -> String {
-        let secp = Secp256k1::new();
-
-        self.encode_silent_payment_address(self.spend_privkey.public_key(&secp))
+        self.encode_silent_payment_address(self.spend_pubkey)
     }
 
     /// Scans a transaction for outputs belonging to us.
@@ -183,7 +183,7 @@ impl Receiver {
     ///
     /// # Returns
     ///
-    /// If successful, the function returns a `Result` wrapping a `HashMap` of labels to a set of private keys (since the same label may have been paid multiple times in one transaction). A resulting `HashMap` of length 0 implies none of the outputs are owned by us.
+    /// If successful, the function returns a `Result` wrapping a `HashMap` of labels to a set of key tweaks (since the same label may have been paid multiple times in one transaction). The key tweaks can be added to the wallet's spending private key to produce a key that can spend the utxo. A resulting `HashMap` of length 0 implies none of the outputs are owned by us.
     ///
     /// # Errors
     ///
@@ -197,19 +197,18 @@ impl Receiver {
         pubkeys_to_check: Vec<XOnlyPublicKey>,
     ) -> Result<HashMap<Label, HashSet<SecretKey>>> {
         let secp = secp256k1::Secp256k1::new();
-        let B_spend = &self.spend_privkey.public_key(&secp);
         let ecdh_shared_secret = self.calculate_shared_secret(tweak_data)?;
 
         let mut my_outputs: HashMap<Label, HashSet<SecretKey>> = HashMap::new();
         let mut n: u32 = 0;
         while my_outputs.len() == n as usize {
-            let t_n: Scalar = calculate_t_n(&ecdh_shared_secret, n)?;
-            let P_n: PublicKey = calculate_P_n(&B_spend, t_n)?;
+            let t_n = calculate_t_n(&ecdh_shared_secret, n)?;
+            let P_n: PublicKey = calculate_P_n(&self.spend_pubkey, t_n.into())?;
             if pubkeys_to_check
                 .iter()
                 .any(|p| p.eq(&P_n.x_only_public_key().0))
             {
-                insert_new_key(self.spend_privkey.add_tweak(&t_n)?, &mut my_outputs, None)?;
+                insert_new_key(t_n, &mut my_outputs, None)?;
             } else if !self.labels.is_empty() {
                 // We subtract P_n from each outputs to check and see if match a public key in our label list
                 'outer: for p in &pubkeys_to_check {
@@ -219,9 +218,9 @@ impl Receiver {
                     let odd_diff = odd_output.combine(&P_n.negate(&secp))?;
 
                     for diff in vec![even_diff, odd_diff] {
-                        if let Some(label) = self.labels.get(&diff) {
+                        if let Some(label) = self.labels.get_by_right(&diff) {
                             insert_new_key(
-                                self.spend_privkey.add_tweak(&t_n)?,
+                                t_n,
                                 &mut my_outputs,
                                 Some(label),
                             )?;
@@ -297,11 +296,9 @@ impl Receiver {
         tweak_data: &PublicKey,
         n: u32,
     ) -> Result<XOnlyPublicKey> {
-        let secp = secp256k1::Secp256k1::new();
-        let B_spend = &self.spend_privkey.public_key(&secp);
         let ecdh_shared_secret = self.calculate_shared_secret(tweak_data)?;
-        let t_n: Scalar = calculate_t_n(&ecdh_shared_secret, n)?;
-        let P_n: PublicKey = calculate_P_n(&B_spend, t_n)?;
+        let t_n = calculate_t_n(&ecdh_shared_secret, n)?;
+        let P_n: PublicKey = calculate_P_n(&self.spend_pubkey, t_n.into())?;
 
         Ok(P_n.x_only_public_key().0)
     }

--- a/src/receiving.rs
+++ b/src/receiving.rs
@@ -195,11 +195,11 @@ impl Receiver {
         &self,
         tweak_data: &PublicKey,
         pubkeys_to_check: Vec<XOnlyPublicKey>,
-    ) -> Result<HashMap<Label, HashSet<SecretKey>>> {
+    ) -> Result<HashMap<Label, Vec<Scalar>>> {
         let secp = secp256k1::Secp256k1::new();
         let ecdh_shared_secret = self.calculate_shared_secret(tweak_data)?;
 
-        let mut my_outputs: HashMap<Label, HashSet<SecretKey>> = HashMap::new();
+        let mut my_outputs: HashMap<Label, Vec<Scalar>> = HashMap::new();
         let mut n: u32 = 0;
         while my_outputs.len() == n as usize {
             let t_n = calculate_t_n(&ecdh_shared_secret, n)?;
@@ -245,7 +245,7 @@ impl Receiver {
     ///
     /// # Returns
     ///
-    /// If successful, the function returns a `Result` wrapping a `HashSet` of private keys. A resulting `HashSet` of length 0 implies none of the outputs are owned by us.
+    /// If successful, the function returns a `Result` wrapping a `Vec` of private key tweaks. A resulting `Vec` of length 0 implies none of the outputs are owned by us.
     ///
     /// # Errors
     ///
@@ -257,7 +257,7 @@ impl Receiver {
         &self,
         tweak_data: &PublicKey,
         pubkeys_to_check: Vec<XOnlyPublicKey>,
-    ) -> Result<HashSet<SecretKey>> {
+    ) -> Result<Vec<Scalar>> {
         if !self.labels.is_empty() {
             return Err(Error::GenericError(
                 "This function should only be used by wallets without labels; use scan_transaction_with_labels instead".to_owned(),
@@ -269,7 +269,7 @@ impl Receiver {
 
         match map.remove(&NULL_LABEL) {
             Some(res) => Ok(res),
-            None => Ok(HashSet::new()),
+            None => Ok(Vec::new()),
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,12 +25,14 @@ pub(crate) fn calculate_P_n(B_spend: &PublicKey, t_n: Scalar) -> Result<PublicKe
     Ok(P_n)
 }
 
-pub(crate) fn calculate_t_n(ecdh_shared_secret: &[u8; 33], n: u32) -> Result<Scalar> {
+pub(crate) fn calculate_t_n(ecdh_shared_secret: &[u8; 33], n: u32) -> Result<SecretKey> {
     let mut bytes: Vec<u8> = Vec::new();
     bytes.extend_from_slice(ecdh_shared_secret);
     bytes.extend_from_slice(&ser_uint32(n));
 
-    Ok(Scalar::from_be_bytes(sha256(&bytes))?)
+    let sk = SecretKey::from_slice(&sha256(&bytes))?;
+
+    Ok(sk)
 }
 
 #[cfg(feature = "receiving")]
@@ -50,7 +52,7 @@ pub(crate) fn insert_new_key(
     let res = my_outputs
         .entry(label.to_owned())
         .or_insert_with(HashSet::new)
-        .insert(new_privkey);
+        .insert(new_privkey.into());
 
     if res {
         Ok(())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,9 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 #[cfg(feature = "receiving")]
 use crate::receiving::{Label, NULL_LABEL};
 
-use crate::{Error, Result};
+use crate::Result;
 use secp256k1::{
     hashes::{sha256, Hash},
     PublicKey, Scalar, Secp256k1, SecretKey,
@@ -38,7 +38,7 @@ pub(crate) fn calculate_t_n(ecdh_shared_secret: &[u8; 33], n: u32) -> Result<Sec
 #[cfg(feature = "receiving")]
 pub(crate) fn insert_new_key(
     mut new_privkey: SecretKey,
-    my_outputs: &mut HashMap<Label, HashSet<SecretKey>>,
+    my_outputs: &mut HashMap<Label, Vec<Scalar>>,
     label: Option<&Label>,
 ) -> Result<()> {
     let label: &Label = match label {
@@ -49,14 +49,10 @@ pub(crate) fn insert_new_key(
         None => &NULL_LABEL,
     };
 
-    let res = my_outputs
+    my_outputs
         .entry(label.to_owned())
-        .or_insert_with(HashSet::new)
-        .insert(new_privkey.into());
+        .or_insert_with(Vec::new)
+        .push(new_privkey.into());
 
-    if res {
-        Ok(())
-    } else {
-        Err(Error::GenericError("Duplicate key found".to_owned()))
-    }
+    Ok(())
 }

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -146,7 +146,7 @@ pub fn hash_outpoints(sending_data: &HashSet<Outpoint>) -> Scalar {
 }
 
 pub fn verify_and_calculate_signatures(
-    privkeys: Vec<SecretKey>,
+    privkeys: Vec<Scalar>,
     b_spend: SecretKey,
 ) -> Result<Vec<OutputWithSignature>, secp256k1::Error> {
     let secp = secp256k1::Secp256k1::new();
@@ -157,7 +157,7 @@ pub fn verify_and_calculate_signatures(
     let mut res: Vec<OutputWithSignature> = vec![];
     for tweak in privkeys {
         // Add the tweak to the b_spend to get the final key
-        let k = b_spend.add_tweak(&Scalar::from(tweak))?;
+        let k = b_spend.add_tweak(&tweak)?;
 
         // get public key
         let P = k.x_only_public_key(&secp).0;
@@ -171,7 +171,7 @@ pub fn verify_and_calculate_signatures(
         // Push result to list
         res.push(OutputWithSignature {
             pub_key: P.to_string(),
-            priv_key_tweak: hex::encode(tweak.secret_bytes()),
+            priv_key_tweak: hex::encode(tweak.to_be_bytes()),
             signature: sig.to_string(),
         });
     }

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -121,6 +121,15 @@ pub fn sender_calculate_shared_secret(
     diffie_hellman.mul_tweak(&secp, &outpoints_hash).unwrap()
 }
 
+pub fn receiver_calculate_shared_secret(
+    tweak_data: PublicKey,
+    b_scan: SecretKey,
+) -> PublicKey {
+    let secp = secp256k1::Secp256k1::new();
+
+    tweak_data.mul_tweak(&secp, &b_scan.into()).unwrap()
+}
+
 pub fn hash_outpoints(sending_data: &HashSet<Outpoint>) -> Scalar {
     let mut outpoints: Vec<Vec<u8>> = vec![];
 

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -155,11 +155,12 @@ pub fn verify_and_calculate_signatures(
     let aux = secp256k1::hashes::sha256::Hash::hash(b"random auxiliary data").into_inner();
 
     let mut res: Vec<OutputWithSignature> = vec![];
-    for k in privkeys {
-        let P = k.x_only_public_key(&secp).0;
+    for tweak in privkeys {
+        // Add the tweak to the b_spend to get the final key
+        let k = b_spend.add_tweak(&Scalar::from(tweak))?;
 
-        // Add the negated b_spend to get only the tweak
-        let tweak = k.add_tweak(&Scalar::from(b_spend.negate()))?;
+        // get public key
+        let P = k.x_only_public_key(&secp).0;
 
         // Sign the message with schnorr
         let sig = secp.sign_schnorr_with_aux_rand(&msg, &k.keypair(&secp), &aux);

--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -8,7 +8,7 @@ mod tests {
         str::FromStr,
     };
 
-    use secp256k1::{PublicKey, Secp256k1, SecretKey};
+    use secp256k1::{PublicKey, Secp256k1, SecretKey, Scalar};
 
     #[cfg(feature = "receiving")]
     use silentpayments::receiving::Receiver;
@@ -134,10 +134,10 @@ mod tests {
                 .scan_transaction_with_labels(&tweak_data, outputs_to_check)
                 .unwrap();
 
-            let privkeys: Vec<SecretKey> = scanned_outputs_received
+            let key_tweaks: Vec<Scalar> = scanned_outputs_received
                 .into_iter()
                 .flat_map(|(_, list)| {
-                    let mut ret: Vec<SecretKey> = vec![];
+                    let mut ret: Vec<Scalar> = vec![];
                     for l in list {
                         ret.push(l);
                     }
@@ -145,7 +145,7 @@ mod tests {
                 })
                 .collect();
 
-            let mut res = verify_and_calculate_signatures(privkeys, b_spend).unwrap();
+            let mut res = verify_and_calculate_signatures(key_tweaks, b_spend).unwrap();
 
             res.sort_by_key(|output| output.pub_key.clone());
             expected

--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -21,7 +21,7 @@ mod tests {
         utils::{
             self, calculate_tweak_data_for_recipient, decode_input_pub_keys, decode_outpoints,
             decode_outputs_to_check, decode_priv_keys, decode_recipients, get_a_sum_secret_keys,
-            hash_outpoints, sender_calculate_shared_secret, verify_and_calculate_signatures,
+            hash_outpoints, sender_calculate_shared_secret, verify_and_calculate_signatures, receiver_calculate_shared_secret
         },
     };
 
@@ -96,8 +96,9 @@ mod tests {
             let b_spend = SecretKey::from_str(&given.spend_priv_key).unwrap();
             let secp = Secp256k1::new();
             let B_spend = b_spend.public_key(&secp);
+            let B_scan = b_scan.public_key(&secp);
 
-            let mut sp_receiver = Receiver::new(0, b_scan, B_spend, IS_TESTNET).unwrap();
+            let mut sp_receiver = Receiver::new(0, B_scan, B_spend, IS_TESTNET).unwrap();
 
             let outputs_to_check = decode_outputs_to_check(&given.outputs);
 
@@ -129,9 +130,10 @@ mod tests {
             assert_eq!(set1, set2);
 
             let tweak_data = calculate_tweak_data_for_recipient(&input_pub_keys, &outpoints);
+            let shared_secret = receiver_calculate_shared_secret(tweak_data, b_scan);
 
             let scanned_outputs_received = sp_receiver
-                .scan_transaction_with_labels(&tweak_data, outputs_to_check)
+                .scan_transaction_with_labels(&shared_secret, outputs_to_check)
                 .unwrap();
 
             let key_tweaks: Vec<Scalar> = scanned_outputs_received

--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -8,7 +8,7 @@ mod tests {
         str::FromStr,
     };
 
-    use secp256k1::{PublicKey, SecretKey};
+    use secp256k1::{PublicKey, Secp256k1, SecretKey};
 
     #[cfg(feature = "receiving")]
     use silentpayments::receiving::Receiver;
@@ -94,8 +94,10 @@ mod tests {
 
             let b_scan = SecretKey::from_str(&given.scan_priv_key).unwrap();
             let b_spend = SecretKey::from_str(&given.spend_priv_key).unwrap();
+            let secp = Secp256k1::new();
+            let B_spend = b_spend.public_key(&secp);
 
-            let mut sp_receiver = Receiver::new(0, b_scan, b_spend, IS_TESTNET).unwrap();
+            let mut sp_receiver = Receiver::new(0, b_scan, B_spend, IS_TESTNET).unwrap();
 
             let outputs_to_check = decode_outputs_to_check(&given.outputs);
 


### PR DESCRIPTION
As discussed in #35 having no private keys in the `Receiver` have some advantages:
* no need to secure the data (making #22 irrelevant)
* we don't need to think of ways to extract the scan and private keys out of the signer (software or hardware)

The downside is that we know to have a signer that is able to compute a DH so that we can compute the shared secret before calling the receiver, but since we already needed that in the first place that's probably not a problem.