### PR TITLE
No scan_privkey in Receiver

### DIFF
--- a/src/receiving.rs
+++ b/src/receiving.rs
@@ -90,7 +90,7 @@ impl From<Label> for Scalar {
 #[derive(Debug)]
 pub struct Receiver {
     version: u8,
-    scan_privkey: SecretKey,
+    scan_pubkey: PublicKey,
     spend_pubkey: PublicKey,
     labels: BiMap<Label, PublicKey>,
     is_testnet: bool,
@@ -99,7 +99,7 @@ pub struct Receiver {
 impl Receiver {
     pub fn new(
         version: u32,
-        scan_privkey: SecretKey,
+        scan_pubkey: PublicKey,
         spend_pubkey: PublicKey,
         is_testnet: bool,
     ) -> Result<Self> {
@@ -114,7 +114,7 @@ impl Receiver {
 
         Ok(Receiver {
             version: version as u8,
-            scan_privkey,
+            scan_pubkey,
             spend_pubkey,
             labels,
             is_testnet,
@@ -178,7 +178,7 @@ impl Receiver {
     ///
     /// # Arguments
     ///
-    /// * `tweak_data` -  The tweak data for the transaction as a PublicKey, the result of elliptic-curve multiplication of `outpoints_hash * A`.
+    /// * `ecdh_shared_secret` -  The ECDH shared secret between sender and recipient as a PublicKey, the result of elliptic-curve multiplication of `(outpoints_hash * sum_inputs_pubkeys) * scan_private_key`.
     /// * `pubkeys_to_check` - A `HashSet` of public keys of all (unspent) taproot output of the transaction.
     ///
     /// # Returns
@@ -193,16 +193,15 @@ impl Receiver {
     /// * An error occurs during elliptic curve computation. This may happen if a sender is being malicious. (?)
     pub fn scan_transaction_with_labels(
         &self,
-        tweak_data: &PublicKey,
+        ecdh_shared_secret: &PublicKey,
         pubkeys_to_check: Vec<XOnlyPublicKey>,
     ) -> Result<HashMap<Label, Vec<Scalar>>> {
         let secp = secp256k1::Secp256k1::new();
-        let ecdh_shared_secret = self.calculate_shared_secret(tweak_data)?;
 
         let mut my_outputs: HashMap<Label, Vec<Scalar>> = HashMap::new();
         let mut n: u32 = 0;
         while my_outputs.len() == n as usize {
-            let t_n: SecretKey = calculate_t_n(&ecdh_shared_secret, n)?;
+            let t_n: SecretKey = calculate_t_n(&ecdh_shared_secret.serialize(), n)?;
             let P_n: PublicKey = calculate_P_n(&self.spend_pubkey, t_n.into())?;
             if pubkeys_to_check
                 .iter()
@@ -280,7 +279,7 @@ impl Receiver {
     ///
     /// # Arguments
     ///
-    /// * `tweak_data` -  The tweak data for the transaction as a PublicKey, the result of elliptic-curve multiplication of `outpoints_hash * A`.
+    /// * `ecdh_shared_secret` -  The ECDH shared secret between sender and recipient as a PublicKey, the result of elliptic-curve multiplication of `(outpoints_hash * sum_inputs_pubkeys) * scan_private_key`.
     ///
     /// # Returns
     ///
@@ -291,12 +290,11 @@ impl Receiver {
     /// This function will return an error if:
     ///
     /// * An error occurs during elliptic curve computation. This may happen if a sender is being malicious. (?)
-    pub fn get_script_bytes_from_tweak_data(
+    pub fn get_script_bytes_from_shared_secret(
         &self,
-        tweak_data: &PublicKey,
+        ecdh_shared_secret: &PublicKey,
     ) -> Result<Vec<u8>> {
-        let ecdh_shared_secret = self.calculate_shared_secret(tweak_data)?;
-        let t_n: SecretKey = calculate_t_n(&ecdh_shared_secret, 0)?;
+        let t_n: SecretKey = calculate_t_n(&ecdh_shared_secret.serialize(), 0)?;
         let P_n: PublicKey = calculate_P_n(&self.spend_pubkey, t_n.into())?;
         let output_key_bytes = P_n.x_only_public_key().0.serialize();
 
@@ -308,41 +306,15 @@ impl Receiver {
         Ok(result)
     }
 
-    /// Helper function that can be used to calculate the elliptic curce shared secret.
-    ///
-    /// # Arguments
-    ///
-    /// * `tweak_data` -  The tweak data given as a PublicKey, the result of elliptic-curve multiplication of the outpoints_hash and `A_sum` (the sum of all input public keys).
-    ///
-    /// # Returns
-    ///
-    /// If successful, the function returns a `Result` wrapping an 33-byte array, which is the shared secret that only the sender and the recipient of a silent payment can derive. This result can be used in the scan_for_outputs function.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if:
-    ///
-    /// * If key multiplication with the scan private key returns an invalid result.
-    fn calculate_shared_secret(&self, tweak_data: &PublicKey) -> Result<[u8; 33]> {
-        let secp = Secp256k1::new();
-
-        let ecdh_shared_secret = tweak_data
-            .mul_tweak(&secp, &self.scan_privkey.into())?
-            .serialize();
-
-        Ok(ecdh_shared_secret)
-    }
-
     fn encode_silent_payment_address(&self, m_pubkey: PublicKey) -> String {
         let hrp = match self.is_testnet {
             false => "sp",
             true => "tsp",
         };
 
-        let secp = Secp256k1::new();
         let version = bech32::u5::try_from_u8(self.version).unwrap();
 
-        let B_scan_bytes = self.scan_privkey.public_key(&secp).serialize();
+        let B_scan_bytes = self.scan_pubkey.serialize();
         let B_m_bytes = m_pubkey.serialize();
 
         let mut data = [B_scan_bytes, B_m_bytes].concat().to_base32();

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -121,6 +121,15 @@ pub fn sender_calculate_shared_secret(
     diffie_hellman.mul_tweak(&secp, &outpoints_hash).unwrap()
 }
 
+pub fn receiver_calculate_shared_secret(
+    tweak_data: PublicKey,
+    b_scan: SecretKey,
+) -> PublicKey {
+    let secp = secp256k1::Secp256k1::new();
+
+    tweak_data.mul_tweak(&secp, &b_scan.into()).unwrap()
+}
+
 pub fn hash_outpoints(sending_data: &HashSet<Outpoint>) -> Scalar {
     let mut outpoints: Vec<Vec<u8>> = vec![];
 

--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -21,7 +21,7 @@ mod tests {
         utils::{
             self, calculate_tweak_data_for_recipient, decode_input_pub_keys, decode_outpoints,
             decode_outputs_to_check, decode_priv_keys, decode_recipients, get_a_sum_secret_keys,
-            hash_outpoints, sender_calculate_shared_secret, verify_and_calculate_signatures,
+            hash_outpoints, sender_calculate_shared_secret, verify_and_calculate_signatures, receiver_calculate_shared_secret
         },
     };
 
@@ -96,8 +96,9 @@ mod tests {
             let b_spend = SecretKey::from_str(&given.spend_priv_key).unwrap();
             let secp = Secp256k1::new();
             let B_spend = b_spend.public_key(&secp);
+            let B_scan = b_scan.public_key(&secp);
 
-            let mut sp_receiver = Receiver::new(0, b_scan, B_spend, IS_TESTNET).unwrap();
+            let mut sp_receiver = Receiver::new(0, B_scan, B_spend, IS_TESTNET).unwrap();
 
             let outputs_to_check = decode_outputs_to_check(&given.outputs);
 
@@ -129,9 +130,10 @@ mod tests {
             assert_eq!(set1, set2);
 
             let tweak_data = calculate_tweak_data_for_recipient(&input_pub_keys, &outpoints);
+            let shared_secret = receiver_calculate_shared_secret(tweak_data, b_scan);
 
             let scanned_outputs_received = sp_receiver
-                .scan_transaction_with_labels(&tweak_data, outputs_to_check)
+                .scan_transaction_with_labels(&shared_secret, outputs_to_check)
                 .unwrap();
 
             let key_tweaks: Vec<Scalar> = scanned_outputs_received


### PR DESCRIPTION
As discussed in #35 having no private keys in the Receiver have some advantages:

* no need to secure the data (making #22 irrelevant)
* we don't need to think of ways to extract the scan and private keys out of the signer (software or hardware)

The downside is that we now need a signer that is able to compute a DH so that we can compute the shared secret before calling the receiver, but since we already needed that in the first place that's probably not a problem.