### PR TITLE
remove unnecessary heap allocation

### DIFF
--- a/src/receiving.rs
+++ b/src/receiving.rs
@@ -216,7 +216,7 @@ impl Receiver {
                     let even_diff = even_output.combine(&P_n.negate(&secp))?;
                     let odd_diff = odd_output.combine(&P_n.negate(&secp))?;
 
-                    for diff in vec![even_diff, odd_diff] {
+                    for diff in [even_diff, odd_diff] {
                         if let Some(label) = self.labels.get_by_right(&diff) {
                             insert_new_key(
                                 t_n,


### PR DESCRIPTION
Was looking through this repo after learning about BIP-352 to try and get a good understanding of silent payments and found an unnecessary heap allocation.

Not sure if `rustc` is smart enough to remove this kind of allocation on it's own, but better to explicitly remove it anyway.