### PR TITLE
Add LabelsNotAllowed error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 #[derive(Debug)]
 pub enum Error {
     GenericError(String),
+    LabelsNotAllowed(String),
     InvalidLabel(String),
     InvalidAddress(String),
     InvalidSharedSecret(String),

--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -102,20 +102,24 @@ mod tests {
 
             let input_pub_keys = decode_input_pub_keys(&given.input_pub_keys);
 
-            for (_, label) in &given.labels {
-                let label = label[..].try_into().unwrap();
-                sp_receiver.add_label(label).unwrap();
-            }
-
             let mut receiving_addresses: HashSet<String> = HashSet::new();
-            // get receiving address for no label
-            receiving_addresses.insert(sp_receiver.get_receiving_address());
 
-            // get receiving addresses for every label
-            let labels = sp_receiver.list_labels();
-            for label in &labels {
-                receiving_addresses
-                    .insert(sp_receiver.get_receiving_address_for_label(label).unwrap());
+            if given.labels.len() == 0 {
+                // get receiving address for no label
+                receiving_addresses.insert(sp_receiver.get_receiving_address().unwrap());
+            } else {
+                // add labels to receiver
+                for (_, label) in &given.labels {
+                    let label = label[..].try_into().unwrap();
+                    sp_receiver.add_label(label).unwrap();
+                }
+
+                // get receiving address for every label
+                let labels = sp_receiver.list_labels();
+                for label in &labels {
+                    receiving_addresses
+                        .insert(sp_receiver.get_receiving_address_for_label(label).unwrap());
+                }
             }
 
             let set1: HashSet<_> = receiving_addresses.iter().collect();


### PR DESCRIPTION
This PR closes #51, but also adds a slightly different logic to how labels are handled. For all label wallets, we assume they also use the NULL_LABEL by default.

The reason for this: we cannot guarantee that the user has not used the null label before adding additional labels.