### PR TITLE
Return map instead of vector for output scanning

### DIFF
--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -134,9 +134,9 @@ mod tests {
 
             let key_tweaks: Vec<Scalar> = scanned_outputs_received
                 .into_iter()
-                .flat_map(|(_, list)| {
+                .flat_map(|(_, map)| {
                     let mut ret: Vec<Scalar> = vec![];
-                    for l in list {
+                    for l in map.into_values() {
                         ret.push(l);
                     }
                     ret


### PR DESCRIPTION
Instead of just returning the scalars in a vector, we return a map from outputs to scalars. This way we can determine which scalar belongs to which of the given transaction outputs.

Closes #57 