### PR TITLE
Serialize receiver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,5 @@ secp256k1 = {version = "0.24", features = ["bitcoin-hashes-std"] }
 hex = "0.4"
 bech32 = "0.9"
 bimap = "0.6"
-
-[dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/receiving.rs
+++ b/src/receiving.rs
@@ -87,7 +87,7 @@ pub struct Receiver {
     scan_pubkey: PublicKey,
     spend_pubkey: PublicKey,
     labels: BiMap<Label, PublicKey>,
-    is_testnet: bool,
+    pub is_testnet: bool,
 }
 
 impl Receiver {

--- a/src/receiving.rs
+++ b/src/receiving.rs
@@ -82,7 +82,7 @@ impl From<Label> for Scalar {
 /// It can be used to scan for transaction outputs belonging to us by using the scan_transaction function.
 /// It optionally supports labels, which it manages internally.
 /// Labels can be added with the add_label function.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Receiver {
     version: u8,
     scan_pubkey: PublicKey,


### PR DESCRIPTION
The big change is the implementation of the Serialize and Deserialize trait for Receiver, which I needed with my last modifications on the backend. 

The other minor changes are making the is_testnet member public and deriving the PartialEq trait for Receiver too.