### PR TITLE
use Option instead of is_empty in get_pubkey_from_input

### DIFF
--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -59,12 +59,22 @@ mod tests {
             let mut input_priv_keys = Vec::new();
             for input in given.vin {
                 let script_sig = hex::decode(&input.scriptSig).unwrap();
+                let script_sig = if script_sig.is_empty() {
+                    None
+                } else {
+                    Some(script_sig.as_slice())
+                };
                 let txinwitness_bytes = hex::decode(&input.txinwitness).unwrap();
-                let mut cursor = Cursor::new(&txinwitness_bytes);
-                let txinwitness = deser_string_vector(&mut cursor).unwrap();
+                let txinwitness = if txinwitness_bytes.is_empty() {
+                    None
+                } else {
+                    let mut cursor = Cursor::new(&txinwitness_bytes);
+                    let txinwitness = deser_string_vector(&mut cursor).unwrap();
+                    Some(txinwitness)
+                };
                 let script_pub_key = hex::decode(&input.prevout.scriptPubKey.hex).unwrap();
 
-                match get_pubkey_from_input(&script_sig, &txinwitness, &script_pub_key) {
+                match get_pubkey_from_input(script_sig, txinwitness.as_ref(), &script_pub_key) {
                     Ok(Some(_pubkey)) => input_priv_keys.push((
                         SecretKey::from_str(&input.private_key).unwrap(),
                         is_p2tr(&script_pub_key),
@@ -124,12 +134,23 @@ mod tests {
             let mut input_pub_keys = Vec::new();
             for input in given.vin {
                 let script_sig = hex::decode(&input.scriptSig).unwrap();
+                let script_sig = if script_sig.is_empty() {
+                    None
+                } else {
+                    Some(script_sig.as_slice())
+                };
                 let txinwitness_bytes = hex::decode(&input.txinwitness).unwrap();
-                let mut cursor = Cursor::new(&txinwitness_bytes);
-                let txinwitness = deser_string_vector(&mut cursor).unwrap();
+                let txinwitness = if txinwitness_bytes.is_empty() {
+                    None
+                } else {
+                    let mut cursor = Cursor::new(&txinwitness_bytes);
+                    let txinwitness = deser_string_vector(&mut cursor).unwrap();
+                    Some(txinwitness)
+                };
+
                 let script_pub_key = hex::decode(&input.prevout.scriptPubKey.hex).unwrap();
 
-                match get_pubkey_from_input(&script_sig, &txinwitness, &script_pub_key) {
+                match get_pubkey_from_input(script_sig, txinwitness.as_ref(), &script_pub_key) {
                     Ok(Some(pubkey)) => input_pub_keys.push(pubkey),
                     Ok(None) => (),
                     Err(e) => panic!("Problem parsing the input: {:?}", e),


### PR DESCRIPTION
# Context 
I am working on a [Silent Payment Indexer](https://github.com/mplsgrant/silent-payment-indexer), and I am using this crate in order to get a feel for its api and to hopefully provide helpful feedback. 

# Issue
The current api for `get_pubkey_from_input` causes me to transform `None` values into empty `&[u8]`.

# Cause
When I arrive at `get_pubkey_from_input` in my code, I have already parsed the `script_sig` and `txinwitness` values which means if they don't exist, I store them as `None` in order to be explicit.

# Solution
I made `get_pubkey_from_input` use Option instead of checking for emptyness. Changing the api meant that I had to update the tests which now look a little uglier as a result. However, it seems like this should make the code cleaner for public consumption.

# Benefits
1. This change makes the presence of `script_sig` and `txinwitnesses` explicit instead of implicit.
2. It pushes parsing closer to the point of data ingress and away from 'business logic' which helps separate concerns and allows other parts of the user's program to take advantage of the data parsing.

# Code checks 
- [x] `cargo test --all-features` still passes
- [x]  Clippy's happiness increased or remained unchanged