### PR TITLE
Add get_network getter to SilentPaymentAddress

### DIFF
--- a/src/sending.rs
+++ b/src/sending.rs
@@ -52,6 +52,10 @@ impl SilentPaymentAddress {
     pub fn get_spend_key(&self) -> PublicKey {
         self.m_pubkey
     }
+
+    pub fn get_network(&self) -> Network {
+        self.network
+    }
 }
 
 impl fmt::Display for SilentPaymentAddress {


### PR DESCRIPTION
That's pretty self explanatory, I noticed while working on other stuff that the network field in the address wasn't public, and that there was no way to compare it with the network value of say a Receiver. I'd rather have a getter like this rather than a public field that can me modified. 