### PR TITLE
Generalize the use of constant time ecdh::shared_secret_point

### DIFF
--- a/examples/find_output.rs
+++ b/examples/find_output.rs
@@ -9,7 +9,7 @@ use bitcoin_hashes::hex::FromHex;
 
 use silentpayments::receiving::{Label, Receiver};
 use silentpayments::utils::receiving::{
-    calculate_shared_point, calculate_tweak_data, get_pubkey_from_input,
+    calculate_ecdh_shared_secret, calculate_tweak_data, get_pubkey_from_input,
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -70,8 +70,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let pubkeys_ref: Vec<&PublicKey> = input_pubkeys.iter().collect();
     let tweak_data = calculate_tweak_data(&pubkeys_ref, &outpoints)?;
-    let ecdh_shared_point = calculate_shared_point(&tweak_data, &scan_privkey);
-    let shared_public_key = PublicKey::from_slice(&ecdh_shared_point)?;
+    let ecdh_shared_secret = calculate_ecdh_shared_secret(&tweak_data, &scan_privkey)?;
 
     let pubkeys_to_check: Vec<_> = tx
         .output
@@ -83,7 +82,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         })
         .collect();
 
-    let my_outputs = receiver.scan_transaction(&shared_public_key, pubkeys_to_check)?;
+    let my_outputs = receiver.scan_transaction(&ecdh_shared_secret, pubkeys_to_check)?;
 
     println!("Found {} outputs", my_outputs.len());
 

--- a/examples/find_output.rs
+++ b/examples/find_output.rs
@@ -9,7 +9,7 @@ use bitcoin_hashes::hex::FromHex;
 
 use silentpayments::receiving::{Label, Receiver};
 use silentpayments::utils::receiving::{
-    calculate_shared_secret, calculate_tweak_data, get_pubkey_from_input,
+    calculate_shared_point, calculate_tweak_data, get_pubkey_from_input,
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -70,7 +70,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let pubkeys_ref: Vec<&PublicKey> = input_pubkeys.iter().collect();
     let tweak_data = calculate_tweak_data(&pubkeys_ref, &outpoints)?;
-    let ecdh_shared_secret = calculate_shared_secret(tweak_data, scan_privkey)?;
+    let ecdh_shared_point = calculate_shared_point(&tweak_data, &scan_privkey);
+    let shared_public_key = PublicKey::from_slice(&ecdh_shared_point)?;
 
     let pubkeys_to_check: Vec<_> = tx
         .output
@@ -82,7 +83,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         })
         .collect();
 
-    let my_outputs = receiver.scan_transaction(&ecdh_shared_secret, pubkeys_to_check)?;
+    let my_outputs = receiver.scan_transaction(&shared_public_key, pubkeys_to_check)?;
 
     println!("Found {} outputs", my_outputs.len());
 

--- a/examples/find_output.rs
+++ b/examples/find_output.rs
@@ -70,7 +70,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let pubkeys_ref: Vec<&PublicKey> = input_pubkeys.iter().collect();
     let tweak_data = calculate_tweak_data(&pubkeys_ref, &outpoints)?;
-    let ecdh_shared_secret = calculate_ecdh_shared_secret(&tweak_data, &scan_privkey)?;
+    let ecdh_shared_secret = calculate_ecdh_shared_secret(&tweak_data, &scan_privkey);
 
     let pubkeys_to_check: Vec<_> = tx
         .output

--- a/src/sending.rs
+++ b/src/sending.rs
@@ -14,7 +14,7 @@ use core::fmt;
 use secp256k1::{PublicKey, Secp256k1, SecretKey, XOnlyPublicKey};
 use std::collections::HashMap;
 
-use crate::utils::sending::calculate_shared_point;
+use crate::utils::sending::calculate_ecdh_shared_secret;
 use crate::{common::calculate_t_n, error::Error, Network, Result};
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
@@ -162,8 +162,7 @@ pub fn generate_recipient_pubkeys(
         if let Some((_, payments)) = silent_payment_groups.get_mut(&B_scan) {
             payments.push(address);
         } else {
-            let shared_point = calculate_shared_point(&B_scan, &partial_secret);
-            let ecdh_shared_secret = PublicKey::from_slice(&shared_point)?;
+            let ecdh_shared_secret = calculate_ecdh_shared_secret(&B_scan, &partial_secret)?;
 
             silent_payment_groups.insert(B_scan, (ecdh_shared_secret, vec![address]));
         }

--- a/src/sending.rs
+++ b/src/sending.rs
@@ -11,9 +11,10 @@
 use bech32::{FromBase32, ToBase32};
 
 use core::fmt;
-use secp256k1::{ecdh::shared_secret_point, PublicKey, Secp256k1, SecretKey, XOnlyPublicKey};
+use secp256k1::{PublicKey, Secp256k1, SecretKey, XOnlyPublicKey};
 use std::collections::HashMap;
 
+use crate::utils::sending::calculate_shared_point;
 use crate::{common::calculate_t_n, error::Error, Network, Result};
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
@@ -161,14 +162,8 @@ pub fn generate_recipient_pubkeys(
         if let Some((_, payments)) = silent_payment_groups.get_mut(&B_scan) {
             payments.push(address);
         } else {
-            // Since PublicKey::from_slice expects an uncompressed public key (0x04<64 bytes>),
-            // we first initialize a 65 byte array and add 0x04 as the first byte
-            let mut ss_bytes = [0u8; 65];
-            ss_bytes[0] = 0x04;
-
-            // Using `shared_secret_point` to ensure the multiplication is constant time
-            ss_bytes[1..].copy_from_slice(&shared_secret_point(&B_scan, &partial_secret));
-            let ecdh_shared_secret = PublicKey::from_slice(&ss_bytes)?;
+            let shared_point = calculate_shared_point(&B_scan, &partial_secret);
+            let ecdh_shared_secret = PublicKey::from_slice(&shared_point)?;
 
             silent_payment_groups.insert(B_scan, (ecdh_shared_secret, vec![address]));
         }

--- a/src/sending.rs
+++ b/src/sending.rs
@@ -162,7 +162,7 @@ pub fn generate_recipient_pubkeys(
         if let Some((_, payments)) = silent_payment_groups.get_mut(&B_scan) {
             payments.push(address);
         } else {
-            let ecdh_shared_secret = calculate_ecdh_shared_secret(&B_scan, &partial_secret)?;
+            let ecdh_shared_secret = calculate_ecdh_shared_secret(&B_scan, &partial_secret);
 
             silent_payment_groups.insert(B_scan, (ecdh_shared_secret, vec![address]));
         }

--- a/src/utils/receiving.rs
+++ b/src/utils/receiving.rs
@@ -59,13 +59,17 @@ pub fn calculate_tweak_data(
 /// This function will error if:
 ///
 /// * Elliptic curve computation results in an invalid public key.
-pub fn calculate_shared_point(tweak_data: &PublicKey, b_scan: &SecretKey) -> [u8; 65] {
+pub fn calculate_ecdh_shared_secret(
+    tweak_data: &PublicKey,
+    b_scan: &SecretKey,
+) -> Result<PublicKey> {
     let mut ss_bytes = [0u8; 65];
     ss_bytes[0] = 0x04;
 
     // Using `shared_secret_point` to ensure the multiplication is constant time
     ss_bytes[1..].copy_from_slice(&shared_secret_point(&tweak_data, &b_scan));
-    ss_bytes
+
+    Ok(PublicKey::from_slice(&ss_bytes)?)
 }
 
 /// Get the public keys from a set of input data.

--- a/src/utils/receiving.rs
+++ b/src/utils/receiving.rs
@@ -59,17 +59,14 @@ pub fn calculate_tweak_data(
 /// This function will error if:
 ///
 /// * Elliptic curve computation results in an invalid public key.
-pub fn calculate_ecdh_shared_secret(
-    tweak_data: &PublicKey,
-    b_scan: &SecretKey,
-) -> Result<PublicKey> {
+pub fn calculate_ecdh_shared_secret(tweak_data: &PublicKey, b_scan: &SecretKey) -> PublicKey {
     let mut ss_bytes = [0u8; 65];
     ss_bytes[0] = 0x04;
 
     // Using `shared_secret_point` to ensure the multiplication is constant time
     ss_bytes[1..].copy_from_slice(&shared_secret_point(&tweak_data, &b_scan));
 
-    Ok(PublicKey::from_slice(&ss_bytes)?)
+    PublicKey::from_slice(&ss_bytes).expect("guaranteed to be a point on the curve")
 }
 
 /// Get the public keys from a set of input data.

--- a/src/utils/receiving.rs
+++ b/src/utils/receiving.rs
@@ -53,12 +53,6 @@ pub fn calculate_tweak_data(
 /// # Returns
 ///
 /// This function returns the shared secret of this transaction. This shared secret can be used to scan the transaction of outputs that are for the current user. See `receiving::scan_transaction`.
-///
-/// # Errors
-///
-/// This function will error if:
-///
-/// * Elliptic curve computation results in an invalid public key.
 pub fn calculate_ecdh_shared_secret(tweak_data: &PublicKey, b_scan: &SecretKey) -> PublicKey {
     let mut ss_bytes = [0u8; 65];
     ss_bytes[0] = 0x04;

--- a/src/utils/sending.rs
+++ b/src/utils/sending.rs
@@ -47,12 +47,6 @@ pub fn calculate_partial_secret(
 /// # Returns
 ///
 /// This function returns the shared secret of this transaction. This shared secret can be used to generate output keys for the recipient.
-///
-/// # Errors
-///
-/// This function will error if:
-///
-/// * Elliptic curve computation results in an invalid public key.
 pub fn calculate_ecdh_shared_secret(B_scan: &PublicKey, partial_secret: &SecretKey) -> PublicKey {
     let mut ss_bytes = [0u8; 65];
     ss_bytes[0] = 0x04;

--- a/src/utils/sending.rs
+++ b/src/utils/sending.rs
@@ -53,17 +53,14 @@ pub fn calculate_partial_secret(
 /// This function will error if:
 ///
 /// * Elliptic curve computation results in an invalid public key.
-pub fn calculate_ecdh_shared_secret(
-    B_scan: &PublicKey,
-    partial_secret: &SecretKey,
-) -> Result<PublicKey> {
+pub fn calculate_ecdh_shared_secret(B_scan: &PublicKey, partial_secret: &SecretKey) -> PublicKey {
     let mut ss_bytes = [0u8; 65];
     ss_bytes[0] = 0x04;
 
     // Using `shared_secret_point` to ensure the multiplication is constant time
     ss_bytes[1..].copy_from_slice(&shared_secret_point(B_scan, partial_secret));
 
-    Ok(PublicKey::from_slice(&ss_bytes)?)
+    PublicKey::from_slice(&ss_bytes).expect("guaranteed to be a point on the curve")
 }
 
 fn get_a_sum_secret_keys(input: &[(SecretKey, bool)]) -> Result<SecretKey> {

--- a/src/utils/sending.rs
+++ b/src/utils/sending.rs
@@ -37,6 +37,8 @@ pub fn calculate_partial_secret(
 
 /// Calculate the shared secret of a transaction.
 ///
+/// Since [`crate::sending::generate_recipient_pubkeys`] calls this function internally, it is not needed for the default sending flow.
+///
 /// # Arguments
 ///
 /// * `B_scan` - The scan public key used by the wallet.
@@ -44,20 +46,24 @@ pub fn calculate_partial_secret(
 ///
 /// # Returns
 ///
-/// This function returns the shared secret point of this transaction. This shared secret can be used to generate output keys for the recipient, see `sending::generate_recipient_pubkeys`
+/// This function returns the shared secret of this transaction. This shared secret can be used to generate output keys for the recipient.
 ///
 /// # Errors
 ///
 /// This function will error if:
 ///
 /// * Elliptic curve computation results in an invalid public key.
-pub fn calculate_shared_point(B_scan: &PublicKey, partial_secret: &SecretKey) -> [u8; 65] {
+pub fn calculate_ecdh_shared_secret(
+    B_scan: &PublicKey,
+    partial_secret: &SecretKey,
+) -> Result<PublicKey> {
     let mut ss_bytes = [0u8; 65];
     ss_bytes[0] = 0x04;
 
     // Using `shared_secret_point` to ensure the multiplication is constant time
     ss_bytes[1..].copy_from_slice(&shared_secret_point(B_scan, partial_secret));
-    ss_bytes
+
+    Ok(PublicKey::from_slice(&ss_bytes)?)
 }
 
 fn get_a_sum_secret_keys(input: &[(SecretKey, bool)]) -> Result<SecretKey> {

--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -7,7 +7,7 @@ mod tests {
         receiving::Label,
         utils::{
             receiving::{
-                calculate_shared_secret, calculate_tweak_data, get_pubkey_from_input, is_p2tr,
+                calculate_shared_point, calculate_tweak_data, get_pubkey_from_input, is_p2tr,
             },
             sending::calculate_partial_secret,
         },
@@ -161,10 +161,11 @@ mod tests {
             assert_eq!(set1, set2);
 
             let tweak_data = calculate_tweak_data(&input_pub_keys, &outpoints).unwrap();
-            let shared_secret = calculate_shared_secret(tweak_data, b_scan).unwrap();
+            let shared_point = calculate_shared_point(&tweak_data, &b_scan);
+            let shared_public_key = PublicKey::from_slice(&shared_point).unwrap();
 
             let scanned_outputs_received = sp_receiver
-                .scan_transaction(&shared_secret, outputs_to_check)
+                .scan_transaction(&shared_public_key, outputs_to_check)
                 .unwrap();
 
             let key_tweaks: Vec<Scalar> = scanned_outputs_received

--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -7,7 +7,7 @@ mod tests {
         receiving::Label,
         utils::{
             receiving::{
-                calculate_shared_point, calculate_tweak_data, get_pubkey_from_input, is_p2tr,
+                calculate_ecdh_shared_secret, calculate_tweak_data, get_pubkey_from_input, is_p2tr,
             },
             sending::calculate_partial_secret,
         },
@@ -161,11 +161,10 @@ mod tests {
             assert_eq!(set1, set2);
 
             let tweak_data = calculate_tweak_data(&input_pub_keys, &outpoints).unwrap();
-            let shared_point = calculate_shared_point(&tweak_data, &b_scan);
-            let shared_public_key = PublicKey::from_slice(&shared_point).unwrap();
+            let ecdh_shared_secret = calculate_ecdh_shared_secret(&tweak_data, &b_scan).unwrap();
 
             let scanned_outputs_received = sp_receiver
-                .scan_transaction(&shared_public_key, outputs_to_check)
+                .scan_transaction(&ecdh_shared_secret, outputs_to_check)
                 .unwrap();
 
             let key_tweaks: Vec<Scalar> = scanned_outputs_received

--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -161,7 +161,7 @@ mod tests {
             assert_eq!(set1, set2);
 
             let tweak_data = calculate_tweak_data(&input_pub_keys, &outpoints).unwrap();
-            let ecdh_shared_secret = calculate_ecdh_shared_secret(&tweak_data, &b_scan).unwrap();
+            let ecdh_shared_secret = calculate_ecdh_shared_secret(&tweak_data, &b_scan);
 
             let scanned_outputs_received = sp_receiver
                 .scan_transaction(&ecdh_shared_secret, outputs_to_check)


### PR DESCRIPTION
Build up on 629ca8062eaa688a6ce70f75839d5216200d76c1 that removes the use of `mul_tweak()` and display 2 distincts `calculate_shared_point()` api in `utils`, one for sending and the other for receiving. While very similar I think that it will help implementors figure out what argument goes where when you're either on receiver or sender side.