### PR TITLE
Move SilentPaymentAddress and Network to utils module

### DIFF
--- a/examples/create_wallet.rs
+++ b/examples/create_wallet.rs
@@ -5,7 +5,7 @@ use bitcoin::bip32::{DerivationPath, Xpriv};
 use bitcoin::secp256k1::Secp256k1;
 
 use silentpayments::receiving::{Label, Receiver};
-use silentpayments::Network;
+use silentpayments::utils::Network;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let secp = Secp256k1::new();

--- a/examples/find_output.rs
+++ b/examples/find_output.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         scan_privkey.public_key(&secp),
         spend_privkey.public_key(&secp),
         change_label,
-        silentpayments::Network::Testnet,
+        silentpayments::utils::Network::Testnet,
     )?;
 
     let outpoints: Vec<(String, u32)> = tx

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,7 +2,6 @@ use crate::utils::hash::SharedSecretHash;
 use crate::Result;
 use bitcoin_hashes::Hash;
 use secp256k1::{PublicKey, Scalar, Secp256k1, SecretKey};
-use serde::{Deserialize, Serialize};
 
 pub(crate) fn calculate_t_n(ecdh_shared_secret: &PublicKey, k: u32) -> Result<SecretKey> {
     let hash = SharedSecretHash::from_ecdh_and_k(ecdh_shared_secret, k).to_byte_array();
@@ -17,11 +16,4 @@ pub(crate) fn calculate_P_n(B_spend: &PublicKey, t_n: Scalar) -> Result<PublicKe
     let P_n = B_spend.add_exp_tweak(&secp, &t_n)?;
 
     Ok(P_n)
-}
-
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Deserialize, Serialize)]
-pub enum Network {
-    Mainnet,
-    Testnet,
-    Regtest,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,3 @@ pub use secp256k1;
 pub use crate::error::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
-pub type Network = common::Network;

--- a/src/receiving.rs
+++ b/src/receiving.rs
@@ -17,8 +17,8 @@ use std::{
 
 use crate::{
     common::{calculate_P_n, calculate_t_n},
-    utils::hash::LabelHash,
-    Error, Network, Result,
+    utils::{hash::LabelHash, Network},
+    Error, Result,
 };
 use bech32::ToBase32;
 use bimap::BiMap;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,6 +8,11 @@ pub mod receiving;
 #[cfg(feature = "sending")]
 pub mod sending;
 
+mod common;
+
+pub use common::Network;
+pub use common::SilentPaymentAddress;
+
 /// [BIP341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki)-defined 'Nothing Up My Sleeve' point.
 pub const NUMS_H: [u8; 32] = [
     0x50, 0x92, 0x9b, 0x74, 0xc1, 0xa0, 0x49, 0x54, 0xb7, 0x8b, 0x4b, 0x60, 0x35, 0xe9, 0x7a, 0x5e,

--- a/src/utils/common.rs
+++ b/src/utils/common.rs
@@ -1,0 +1,129 @@
+use core::fmt;
+
+use crate::Error;
+use crate::Result;
+use bech32::{FromBase32, ToBase32};
+use secp256k1::PublicKey;
+use serde::{Deserialize, Serialize};
+
+/// The network format used for this silent payment address.
+///
+/// There are three network types: Mainnet (`sp1..`), Testnet (`tsp1..`), and Regtest (`sprt1..`).
+/// Signet uses the same network type as Testnet.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Deserialize, Serialize)]
+pub enum Network {
+    Mainnet,
+    Testnet,
+    Regtest,
+}
+
+/// A silent payment address struct that can be used to deserialize a silent payment address string.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub struct SilentPaymentAddress {
+    version: u8,
+    scan_pubkey: PublicKey,
+    m_pubkey: PublicKey,
+    network: Network,
+}
+
+impl SilentPaymentAddress {
+    pub fn new(
+        scan_pubkey: PublicKey,
+        m_pubkey: PublicKey,
+        network: Network,
+        version: u8,
+    ) -> Result<Self> {
+        if version != 0 {
+            return Err(Error::GenericError(
+                "Can't have other version than 0 for now".to_owned(),
+            ));
+        }
+
+        Ok(SilentPaymentAddress {
+            scan_pubkey,
+            m_pubkey,
+            network,
+            version,
+        })
+    }
+
+    pub fn get_scan_key(&self) -> PublicKey {
+        self.scan_pubkey
+    }
+
+    pub fn get_spend_key(&self) -> PublicKey {
+        self.m_pubkey
+    }
+
+    pub fn get_network(&self) -> Network {
+        self.network
+    }
+}
+
+impl fmt::Display for SilentPaymentAddress {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", <SilentPaymentAddress as Into<String>>::into(*self))
+    }
+}
+
+impl TryFrom<&str> for SilentPaymentAddress {
+    type Error = Error;
+
+    fn try_from(addr: &str) -> Result<Self> {
+        let (hrp, data, _variant) = bech32::decode(addr)?;
+
+        if data.len() != 107 {
+            return Err(Error::GenericError("Address length is wrong".to_owned()));
+        }
+
+        let version = data[0].to_u8();
+
+        let network = match hrp.as_str() {
+            "sp" => Network::Mainnet,
+            "tsp" => Network::Testnet,
+            "sprt" => Network::Regtest,
+            _ => {
+                return Err(Error::InvalidAddress(format!(
+                    "Wrong prefix, expected \"sp\", \"tsp\", or \"sprt\", got \"{}\"",
+                    &hrp
+                )))
+            }
+        };
+
+        let data = Vec::<u8>::from_base32(&data[1..])?;
+
+        let scan_pubkey = PublicKey::from_slice(&data[..33])?;
+        let m_pubkey = PublicKey::from_slice(&data[33..])?;
+
+        SilentPaymentAddress::new(scan_pubkey, m_pubkey, network, version)
+    }
+}
+
+impl TryFrom<String> for SilentPaymentAddress {
+    type Error = Error;
+
+    fn try_from(addr: String) -> Result<Self> {
+        addr.as_str().try_into()
+    }
+}
+
+impl From<SilentPaymentAddress> for String {
+    fn from(val: SilentPaymentAddress) -> Self {
+        let hrp = match val.network {
+            Network::Testnet => "tsp",
+            Network::Regtest => "sprt",
+            Network::Mainnet => "sp",
+        };
+
+        let version = bech32::u5::try_from_u8(val.version).unwrap();
+
+        let B_scan_bytes = val.scan_pubkey.serialize();
+        let B_m_bytes = val.m_pubkey.serialize();
+
+        let mut data = [B_scan_bytes, B_m_bytes].concat().to_base32();
+
+        data.insert(0, version);
+
+        bech32::encode(hrp, data, bech32::Variant::Bech32m).unwrap()
+    }
+}

--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -10,8 +10,8 @@ mod tests {
                 calculate_ecdh_shared_secret, calculate_tweak_data, get_pubkey_from_input, is_p2tr,
             },
             sending::calculate_partial_secret,
+            Network,
         },
-        Network,
     };
     use std::{collections::HashSet, io::Cursor, str::FromStr};
 


### PR DESCRIPTION
These structs are not meant to be used for the default sending and
receiving flow, but can still be quite useful. Therefore the utils
module is probably the best place for them.